### PR TITLE
Update codecov YML settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,20 @@
+codecov:
+  require_ci_to_pass: true
+
 coverage:
+  precision: 2
+  round: down
+  range: "40...90"
   status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
     patch:
       default:
-        target: 50%
-        threshold: 5
+        # Enforce patch coverage on PRs, but do not fail direct commits on main.
+        only_pulls: true
+        target: auto
+
+ignore:
+  - "assets/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,7 +14,7 @@ coverage:
       default:
         # Enforce patch coverage on PRs, but do not fail direct commits on main.
         only_pulls: true
-        target: auto
+        target: null
 
 ignore:
   - "assets/*"


### PR DESCRIPTION
Sync codecov settings in BRIDGE with those in VERTEX, including specifically ensuring that the patch diff requirements only apply to PRs, not updates of `main` on merges.