### PR TITLE
Replace CC license refs in source with MIT

### DIFF
--- a/bridge/generate_pdf/header_footer.py
+++ b/bridge/generate_pdf/header_footer.py
@@ -7,7 +7,9 @@ from reportlab.platypus.doctemplate import SimpleDocTemplate
 CURRENT_DATE = datetime.now()
 FORMATTED_DATE = CURRENT_DATE.strftime("%d%b%y").upper()
 ISARIC_LOGO = "assets/ISARIC_logo.png"
-LICENSE_TEXT = "Licensed under the MIT license by ISARIC on behalf of the University of Oxford."
+LICENSE_TEXT = (
+    "Licensed under the MIT license by ISARIC on behalf of the University of Oxford."
+)
 
 
 def set_paperlike_header_content(canvas: Canvas):

--- a/bridge/generate_pdf/header_footer.py
+++ b/bridge/generate_pdf/header_footer.py
@@ -7,7 +7,7 @@ from reportlab.platypus.doctemplate import SimpleDocTemplate
 CURRENT_DATE = datetime.now()
 FORMATTED_DATE = CURRENT_DATE.strftime("%d%b%y").upper()
 ISARIC_LOGO = "assets/ISARIC_logo.png"
-LICENSE_TEXT = "Licensed under a Creative Commons Attribution-ShareAlike 4.0 International License by ISARIC on behalf of the University of Oxford."
+LICENSE_TEXT = "Licensed under the MIT license by ISARIC on behalf of the University of Oxford."
 
 
 def set_paperlike_header_content(canvas: Canvas):

--- a/bridge/layout/app_layout.py
+++ b/bridge/layout/app_layout.py
@@ -97,10 +97,10 @@ class MainContent:
                                                 href="mailto:data@isaric.org",
                                             ),
                                             ". ",
-                                            "Licensed under a ",
+                                            "Licensed under the ",
                                             html.A(
-                                                "Creative Commons Attribution-ShareAlike 4.0 ",
-                                                href="https://creativecommons.org/licenses/by-sa/4.0/",
+                                                "MIT License ",
+                                                href="https://opensource.org/license/mit",
                                                 target="_blank",
                                             ),
                                             "International License by ",

--- a/bridge/layout/app_layout.py
+++ b/bridge/layout/app_layout.py
@@ -103,7 +103,7 @@ class MainContent:
                                                 href="https://opensource.org/license/mit",
                                                 target="_blank",
                                             ),
-                                            "International License by ",
+                                            " by ",
                                             html.A(
                                                 "ISARIC",
                                                 href="https://isaric.org/",

--- a/bridge/layout/index.py
+++ b/bridge/layout/index.py
@@ -701,10 +701,10 @@ class Index:
                                 [
                                     html.P(
                                         [
-                                            "Licensed under a ",
+                                            "Licensed under the ",
                                             html.A(
-                                                "Creative Commons Attribution-ShareAlike 4.0",
-                                                href="https://creativecommons.org/licenses/by-sa/4.0/",
+                                                "MIT License",
+                                                href="https://opensource.org/license/mit",
                                                 target="_blank",
                                             ),
                                             " International License by ",

--- a/bridge/layout/index.py
+++ b/bridge/layout/index.py
@@ -707,7 +707,7 @@ class Index:
                                                 href="https://opensource.org/license/mit",
                                                 target="_blank",
                                             ),
-                                            " International License by ",
+                                            " by ",
                                             html.A(
                                                 "ISARIC",
                                                 href="https://isaric.org/",


### PR DESCRIPTION
For consistency with the current license file which is MIT, all license refs in the app files have been updated. The license footer now appears as below:

<img width="961" height="57" alt="Screenshot 2026-06-05 at 15 18 58" src="https://github.com/user-attachments/assets/d33e30c0-f67c-48c4-8b65-cb3cb35d8a05" />
